### PR TITLE
gitlab adjustment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,4 +37,4 @@ release-image:
     - docker push $CONTAINER_RELEASE_IMAGE
     - docker push $CONTAINER_LATEST_IMAGE
   only:
-    - master
+    - tags


### PR DESCRIPTION
Only perform release step when a tag is pushed

Following the rename of the branch to master 
the release step was run in gitlab, it will now happen when a tag is pushed

Change has been made to gitlab repo too. See https://gitlab.com/openmicroscopy/incubator/omero-downloader/pipelines/40871666