### PR TITLE
Fix the bat

### DIFF
--- a/download.bat
+++ b/download.bat
@@ -4,9 +4,9 @@ set SCRIPT_DIR=%~dp0
 set JAR_FILE=downloader-jar-with-dependencies.jar
 
 if exist "%SCRIPT_DIR%"\%JAR_FILE% (
-  java -jar "%SCRIPT_DIR%"\%JAR_FILE% %*
+  java -jar "%SCRIPT_DIR%\%JAR_FILE%" %*
 ) else if exist "%SCRIPT_DIR%"\target\%JAR_FILE% (
-  java -jar "%SCRIPT_DIR%"\target\%JAR_FILE% %*
+  java -jar "%SCRIPT_DIR%\target\%JAR_FILE%" %*
 ) else (
   echo Failed to find JAR file named %JAR_FILE%
 )

--- a/download.bat
+++ b/download.bat
@@ -3,9 +3,9 @@
 set SCRIPT_DIR=%~dp0
 set JAR_FILE=downloader-jar-with-dependencies.jar
 
-if exist "%SCRIPT_DIR%"\%JAR_FILE% (
+if exist "%SCRIPT_DIR%\%JAR_FILE%" (
   java -jar "%SCRIPT_DIR%\%JAR_FILE%" %*
-) else if exist "%SCRIPT_DIR%"\target\%JAR_FILE% (
+) else if exist "%SCRIPT_DIR%\target\%JAR_FILE%" (
   java -jar "%SCRIPT_DIR%\target\%JAR_FILE%" %*
 ) else (
   echo Failed to find JAR file named %JAR_FILE%


### PR DESCRIPTION
This should suggest a fix of the ``download.bat`` script on Windows. 
The suggested fix is inspired by @joshmoore 's comment pointing to https://github.com/openmicroscopy/openmicroscopy/blob/develop/components/tools/OmeroPy/bin/omero.bat

See [trello card](https://trello.com/c/CyoTSMbZ/55-bug-downloadbat-is-broken).

This fix works for me as tested on Windows 7 laptop. Admittedly, I think that I am always testing just the first ``if`` case, namely, when my ``download.bat`` is in the same dir as the jar.
But then, I guess this is the more common case.
To be fair, I do not completely understand the second ``else if`` with the ``target`` inside the path - do not see the ``target`` defined in that file.

See what you think

@joshmoore @mtbc 

To test:

1.
 - On Windows, get the downloader from https://github.com/ome/omero-downloader/releases/download/v0.1.2/OMERO.downloader-0.1.2-release.zip
 - Extract the files and cd  into the folder, so that you are in the dir where the ``download.bat`` is.
 - Manually create a target directory, easiest for me was to create a dir directly inside the folder where I was
 - Run ``download.bat -b <path-to-directory-you-just-created> -s <server host> -u <user name> -w <password> -f binary Image:<image ID>`` 
 - you should observe output reporting successful downloads

2.
 - Create a directory under the dir where your ``download.bat`` called "target" and move the ``downloader-jar-with-dependencies.jar`` into the directory you just created.
 - Run again the command from test 1. above
 - you should observe output reporting successful downloads

3. 
 - move the ``downloader-jar-with-dependencies.jar`` to some other directory than the two dirs described in step 1. and 2. above, or delete it.
 - Run again the command from test 1. above
 - you should not download anything, instead the output should say  ``Failed to find JAR file named downloader-jar-with-dependencies.jar``