### PR TITLE
Remove SNAPSHOT from version, in preparation for release.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
   <groupId>omero</groupId>
   <artifactId>downloader</artifactId>
-  <version>0.1.3-SNAPSHOT</version>
+  <version>0.1.3</version>
 
   <name>OMERO.downloader</name>
   <description>OMERO client for downloading data in bulk from the server</description>


### PR DESCRIPTION
Simply removes the `-SNAPSHOT` from the POM.