### PR TITLE
fix TIFF and OME-TIFF export

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,24 @@ Additionally, specifying `-a` extends the targeted images to include all
 that are in the same fileset as any targeted image.
 
 
-# Fetching metadata
+# Exporting images
 
-Image metadata is available as OME-XML without pixel data.
-The included metadata can be limited with the `-x` option.
+A workaround to not being able to download plates is to instead export
+their images as TIFF. The `-f` option supports `tiff` and `ome-tiff`.
+
+Big images can be exported. Repeating an export resumes any interrupted
+image tile downloads and skips images that were already exported.
+
+The metadata included in OME-TIFF export currently includes that of the
+images, ROIs, and some of the simple kinds of annotation on either of
+those. This can be limited with the `-x` option if less metadata is
+desired.
+
+
+# Fetching metadata only
+
+Image metadata is available as OME-XML without pixel data. As for
+OME-TIFF export the `-x` option also limits download of this.
 
 `ome-xml-parts` downloads metadata for images, ROIs and some simple
 annotations on them as many standalone XML files. For example, with,

--- a/src/main/java/org/openmicroscopy/client/downloader/Download.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/Download.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2016-2019 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -640,7 +640,7 @@ public class Download {
                             /* Downloaded tiles are over 3GB so resulting TIFF may be larger still. */
                             writer.setBigTiff(true);
                         }
-                        writer.setCompression(TiffWriter.COMPRESSION_J2K);
+                        writer.setCompression(TiffWriter.COMPRESSION_ZLIB);
                         writer.setMetadataRetrieve(metadata);
                         writer.setId(tiffFile.getPath());
                         localPixels.writeTiles(writer);

--- a/src/main/java/org/openmicroscopy/client/downloader/metadata/ImageMetadata.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/metadata/ImageMetadata.java
@@ -50,6 +50,8 @@ import org.joda.time.Instant;
 
 /**
  * An instance of {@link loci.formats.meta.MetadataRetrieve} that provides metadata about OMERO images.
+ * Differs from {@link ome.services.blitz.impl.OmeroMetadata} in that {@link #getPixelsDimensionOrder(int)}
+ * reflects {@link loci.formats.in.TiffReader}'s ImageJ convention for 5D data for ease of exporting plain TIFFs.
  * @author m.t.b.carroll@dundee.ac.uk
  * @author Josh Moore josh at glencoesoftware.com
  * @author Chris Allan callan at blackcat.ca
@@ -178,7 +180,7 @@ public class ImageMetadata extends MetadataBase {
     @Override
     public DimensionOrder getPixelsDimensionOrder(int imageIndex)
     {
-        return DimensionOrder.XYZCT;
+        return DimensionOrder.XYCZT;
     }
 
     @Override

--- a/src/main/java/org/openmicroscopy/client/downloader/options/OptionParser.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/options/OptionParser.java
@@ -141,7 +141,7 @@ public class OptionParser {
 
     private static final OptionSet fileTypes = new OptionSet(Arrays.asList(
             "binary", "companion", "tiff", "ome-tiff", "ome-xml", "ome-xml-whole", "ome-xml-parts"),
-            Collections.<String>emptySet()).hide("tiff").hide("ome-tiff");
+            Collections.<String>emptySet());
     private static final OptionSet objectTypes = new OptionSet(Arrays.asList(
             // TODO: include "project", "dataset", "folder", "experiment", "instrument", "screen", "plate"
             "image", "annotation", "roi"),


### PR DESCRIPTION
The `tiff` and `ome-tiff` options for `downloader.sh`'s `-f` option should now work fine. *Check* the exported files: reimport into OMERO or use `showinf` or some non-OME tool.