### PR TITLE
Allow download when symlinks cannot be made.

### DIFF
--- a/src/main/java/org/openmicroscopy/client/downloader/Download.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/Download.java
@@ -321,7 +321,7 @@ public class Download {
             file1.toFile().deleteOnExit();
             Files.delete(file2);
             try {
-                Files.createSymbolicLink(file1, file2);
+                Files.createSymbolicLink(file2, file1.toAbsolutePath());
                 isCanLink = true;
                 Files.delete(file2);
             } catch (FileSystemException fse) {


### PR DESCRIPTION
With `-f binary,companion` links are made from `Fileset/` and `Image/` unless `-l none` is specified. This option *must* be specified for some regular Windows users because they do not have permission to link files!

This PR makes for a softer landing in situations like https://github.com/ome/omero-downloader/pull/6#issuecomment-458059256 such that it warns then still performs the download into `Repository/` without making the user specify `-l none` explicitly.

If reviewing the code diff, probably easier as separate commits as a large one is whitespace-only. The refactoring was to ensure that `finally` blocks would be executed.