### PR TITLE
Export reworking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,8 +38,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <ice.version>ice36</ice.version>
   </properties>
 

--- a/src/main/java/org/openmicroscopy/client/downloader/Download.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/Download.java
@@ -19,7 +19,6 @@
 
 package org.openmicroscopy.client.downloader;
 
-import com.google.common.base.Function;
 import com.google.common.base.Splitter;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
@@ -47,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/src/main/java/org/openmicroscopy/client/downloader/Download.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/Download.java
@@ -715,33 +715,24 @@ public class Download {
     private static void writeXmlObjects(Map<Map.Entry<ModelType, ModelType>, SetMultimap<Long, Long>> containment,
             final SetMultimap<ModelType, Long> objects) {
         if (objects.containsKey(ModelType.ANNOTATION)) {
-            xmlGenerator.writeAnnotations(ImmutableList.copyOf(objects.get(ModelType.ANNOTATION)), new Function<Long, File>() {
-                @Override
-                public File apply(Long id) {
-                    final File file = paths.getMetadataFile(ModelType.ANNOTATION, id);
-                    file.getParentFile().mkdirs();
-                    return file;
-                }
+            xmlGenerator.writeAnnotations(ImmutableList.copyOf(objects.get(ModelType.ANNOTATION)), (Long id) -> {
+                final File file = paths.getMetadataFile(ModelType.ANNOTATION, id);
+                file.getParentFile().mkdirs();
+                return file;
             });
         }
         if (objects.containsKey(ModelType.IMAGE)) {
-            xmlGenerator.writeImages(ImmutableList.copyOf(objects.get(ModelType.IMAGE)), new Function<Long, File>() {
-                @Override
-                public File apply(Long id) {
-                    final File file = paths.getMetadataFile(ModelType.IMAGE, id);
-                    file.getParentFile().mkdirs();
-                    return file;
-                }
+            xmlGenerator.writeImages(ImmutableList.copyOf(objects.get(ModelType.IMAGE)), (Long id) -> {
+                final File file = paths.getMetadataFile(ModelType.IMAGE, id);
+                file.getParentFile().mkdirs();
+                return file;
             });
         }
         if (objects.containsKey(ModelType.ROI)) {
-            xmlGenerator.writeRois(ImmutableList.copyOf(objects.get(ModelType.ROI)), new Function<Long, File>() {
-                @Override
-                public File apply(Long id) {
-                    final File file = paths.getMetadataFile(ModelType.ROI, id);
-                    file.getParentFile().mkdirs();
-                    return file;
-                }
+            xmlGenerator.writeRois(ImmutableList.copyOf(objects.get(ModelType.ROI)), (Long id) -> {
+                final File file = paths.getMetadataFile(ModelType.ROI, id);
+                file.getParentFile().mkdirs();
+                return file;
             });
         }
         try {
@@ -783,12 +774,8 @@ public class Download {
         /* map parent-child relationships */
         final Map<Map.Entry<ModelType, ModelType>, SetMultimap<Long, Long>> containment =
                 new ParentChildMap(objects.keySet()).buildFromFS().containment;
-        final Function<Map.Entry<ModelType, Long>, File> metadataFiles = new Function<Map.Entry<ModelType, Long>, File>() {
-            @Override
-            public File apply(Map.Entry<ModelType, Long> input) {
-                return paths.getMetadataFile(input.getKey(), input.getValue());
-            }
-        };
+        final Function<Map.Entry<ModelType, Long>, File> metadataFiles = (Map.Entry<ModelType, Long> input) ->
+                paths.getMetadataFile(input.getKey(), input.getValue());
         try {
             if (objects.containsKey(ModelType.IMAGE)) {
                 final Set<Long> imageIds = objects.get(ModelType.IMAGE);

--- a/src/main/java/org/openmicroscopy/client/downloader/Download.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/Download.java
@@ -693,7 +693,6 @@ public class Download {
                         }
                         writer.setCompression(TiffWriter.COMPRESSION_ZLIB);
                         writer.setMetadataRetrieve(metadata);
-                        writer.setWriteSequentially(true);
                         writer.setId(tiffFile.getPath());
                         localPixels.writeTiles(writer);
                     }

--- a/src/main/java/org/openmicroscopy/client/downloader/LinkMakerMetadata.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/LinkMakerMetadata.java
@@ -24,10 +24,10 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 import loci.formats.meta.IMetadata;
 
-import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 
@@ -66,92 +66,56 @@ public class LinkMakerMetadata {
         }
         final ImmutableMap.Builder<Long, Integer> annotationMap = ImmutableMap.builder();
         try {
-            buildMetadataIndex(annotationMap, AnnotationType.BOOLEAN, new Function<Integer, String>() {
-                @Override
-                public String apply(Integer index) {
-                    return metadata.getBooleanAnnotationID(index);
-                }
-            }, metadata.getBooleanAnnotationCount());
+            buildMetadataIndex(annotationMap, AnnotationType.BOOLEAN, metadata::getBooleanAnnotationID,
+                    metadata.getBooleanAnnotationCount());
         } catch (NullPointerException npe) {
             /* count is zero so move on to next */
         }
         try {
-            buildMetadataIndex(annotationMap, AnnotationType.COMMENT, new Function<Integer, String>() {
-                @Override
-                public String apply(Integer index) {
-                    return metadata.getCommentAnnotationID(index);
-                }
-            }, metadata.getCommentAnnotationCount());
+            buildMetadataIndex(annotationMap, AnnotationType.COMMENT, metadata::getCommentAnnotationID,
+                    metadata.getCommentAnnotationCount());
         } catch (NullPointerException npe) {
             /* count is zero so move on to next */
         }
         try {
-            buildMetadataIndex(annotationMap, AnnotationType.DOUBLE, new Function<Integer, String>() {
-                @Override
-                public String apply(Integer index) {
-                    return metadata.getDoubleAnnotationID(index);
-                }
-            }, metadata.getDoubleAnnotationCount());
+            buildMetadataIndex(annotationMap, AnnotationType.DOUBLE, metadata::getDoubleAnnotationID,
+                    metadata.getDoubleAnnotationCount());
         } catch (NullPointerException npe) {
             /* count is zero so move on to next */
         }
         try {
-            buildMetadataIndex(annotationMap, AnnotationType.LONG, new Function<Integer, String>() {
-                @Override
-                public String apply(Integer index) {
-                    return metadata.getLongAnnotationID(index);
-                }
-            }, metadata.getLongAnnotationCount());
+            buildMetadataIndex(annotationMap, AnnotationType.LONG, metadata::getLongAnnotationID,
+                    metadata.getLongAnnotationCount());
         } catch (NullPointerException npe) {
             /* count is zero so move on to next */
         }
         try {
-            buildMetadataIndex(annotationMap, AnnotationType.MAP, new Function<Integer, String>() {
-                @Override
-                public String apply(Integer index) {
-                    return metadata.getMapAnnotationID(index);
-                }
-            }, metadata.getMapAnnotationCount());
+            buildMetadataIndex(annotationMap, AnnotationType.MAP, metadata::getMapAnnotationID,
+                    metadata.getMapAnnotationCount());
         } catch (NullPointerException npe) {
             /* count is zero so move on to next */
         }
         try {
-            buildMetadataIndex(annotationMap, AnnotationType.TAG, new Function<Integer, String>() {
-                @Override
-                public String apply(Integer index) {
-                    return metadata.getTagAnnotationID(index);
-                }
-            }, metadata.getTagAnnotationCount());
+            buildMetadataIndex(annotationMap, AnnotationType.TAG, metadata::getTagAnnotationID,
+                    metadata.getTagAnnotationCount());
         } catch (NullPointerException npe) {
             /* count is zero so move on to next */
         }
         try {
-            buildMetadataIndex(annotationMap, AnnotationType.TERM, new Function<Integer, String>() {
-                @Override
-                public String apply(Integer index) {
-                    return metadata.getTermAnnotationID(index);
-                }
-            }, metadata.getTermAnnotationCount());
+            buildMetadataIndex(annotationMap, AnnotationType.TERM, metadata::getTermAnnotationID,
+                    metadata.getTermAnnotationCount());
         } catch (NullPointerException npe) {
             /* count is zero so move on to next */
         }
         try {
-            buildMetadataIndex(annotationMap, AnnotationType.TIMESTAMP, new Function<Integer, String>() {
-                @Override
-                public String apply(Integer index) {
-                    return metadata.getTimestampAnnotationID(index);
-                }
-            }, metadata.getTimestampAnnotationCount());
+            buildMetadataIndex(annotationMap, AnnotationType.TIMESTAMP, metadata::getTimestampAnnotationID,
+                    metadata.getTimestampAnnotationCount());
         } catch (NullPointerException npe) {
             /* count is zero so move on to next */
         }
         try {
-            buildMetadataIndex(annotationMap, AnnotationType.XML, new Function<Integer, String>() {
-                @Override
-                public String apply(Integer index) {
-                    return metadata.getXMLAnnotationID(index);
-                }
-            }, metadata.getXMLAnnotationCount());
+            buildMetadataIndex(annotationMap, AnnotationType.XML, metadata::getXMLAnnotationID,
+                    metadata.getXMLAnnotationCount());
         } catch (NullPointerException npe) {
             /* count is zero so move on to next */
         }
@@ -163,12 +127,7 @@ public class LinkMakerMetadata {
             imageCount = 0;
         }
         indexMap.put(ModelType.IMAGE, imageCount == 0 ? Collections.<Long, Integer>emptyMap() :
-                 buildMetadataIndex(ImmutableMap.<Long, Integer>builder(), null, new Function<Integer, String>() {
-                    @Override
-                    public String apply(Integer index) {
-                        return metadata.getImageID(index);
-                    }
-                }, imageCount).build());
+                 buildMetadataIndex(ImmutableMap.<Long, Integer>builder(), null, metadata::getImageID, imageCount).build());
         int roiCount;
         try {
             roiCount = metadata.getROICount();
@@ -176,12 +135,7 @@ public class LinkMakerMetadata {
             roiCount = 0;
         }
         indexMap.put(ModelType.ROI, roiCount == 0 ? Collections.<Long, Integer>emptyMap() :
-                buildMetadataIndex(ImmutableMap.<Long, Integer>builder(), null, new Function<Integer, String>() {
-                    @Override
-                    public String apply(Integer index) {
-                        return metadata.getROIID(index);
-                    }
-                }, roiCount).build());
+                buildMetadataIndex(ImmutableMap.<Long, Integer>builder(), null, metadata::getROIID, roiCount).build());
         indices = indexMap.build();
     }
 

--- a/src/main/java/org/openmicroscopy/client/downloader/LinkMakerMetadata.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/LinkMakerMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2018-2019 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -38,7 +38,7 @@ import com.google.common.collect.Maps;
 public class LinkMakerMetadata {
 
     private static enum AnnotationType {
-        BOOLEAN, COMMENT, DOUBLE, LONG, TAG, TERM, TIMESTAMP, XML;
+        BOOLEAN, COMMENT, DOUBLE, LONG, MAP, TAG, TERM, TIMESTAMP, XML;
     }
 
     private final IMetadata metadata;
@@ -102,6 +102,16 @@ public class LinkMakerMetadata {
                     return metadata.getLongAnnotationID(index);
                 }
             }, metadata.getLongAnnotationCount());
+        } catch (NullPointerException npe) {
+            /* count is zero so move on to next */
+        }
+        try {
+            buildMetadataIndex(annotationMap, AnnotationType.MAP, new Function<Integer, String>() {
+                @Override
+                public String apply(Integer index) {
+                    return metadata.getMapAnnotationID(index);
+                }
+            }, metadata.getMapAnnotationCount());
         } catch (NullPointerException npe) {
             /* count is zero so move on to next */
         }
@@ -237,6 +247,9 @@ public class LinkMakerMetadata {
                     case LONG:
                         lsid = metadata.getLongAnnotationID(toIndex);
                         break;
+                    case MAP:
+                        lsid = metadata.getMapAnnotationID(toIndex);
+                        break;
                     case TAG:
                         lsid = metadata.getTagAnnotationID(toIndex);
                         break;
@@ -282,6 +295,10 @@ public class LinkMakerMetadata {
                             case LONG:
                                 metadata.setLongAnnotationAnnotationRef(lsid, fromIndex,
                                         metadata.getLongAnnotationAnnotationCount(fromIndex));
+                                break;
+                            case MAP:
+                                metadata.setMapAnnotationAnnotationRef(lsid, fromIndex,
+                                        metadata.getMapAnnotationAnnotationCount(fromIndex));
                                 break;
                             case TAG:
                                 metadata.setTagAnnotationAnnotationRef(lsid, fromIndex,

--- a/src/main/java/org/openmicroscopy/client/downloader/LocalPaths.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/LocalPaths.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2016-2019 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -37,12 +37,7 @@ import com.google.common.collect.ImmutableMap;
  */
 public class LocalPaths {
 
-    private static final FileFilter IS_DIRECTORY = new FileFilter() {
-        @Override
-        public boolean accept(File file) {
-            return file.isDirectory();
-        }
-    };
+    private static final FileFilter IS_DIRECTORY = File::isDirectory;
 
     private static final Function<String, String> SANITIZER = new MakePathComponentSafe(
             FilePathRestrictionInstance.getFilePathRestrictions(FilePathRestrictionInstance.LOCAL_REQUIRED));

--- a/src/main/java/org/openmicroscopy/client/downloader/XmlAssembler.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/XmlAssembler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2018-2019 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -48,6 +48,7 @@ import ome.xml.model.BooleanAnnotation;
 import ome.xml.model.CommentAnnotation;
 import ome.xml.model.DoubleAnnotation;
 import ome.xml.model.LongAnnotation;
+import ome.xml.model.MapAnnotation;
 import ome.xml.model.OME;
 import ome.xml.model.OMEModel;
 import ome.xml.model.OMEModelObject;
@@ -337,6 +338,9 @@ public class XmlAssembler implements Closeable {
                     break;
                 case "LongAnnotation":
                     annotationType = LongAnnotation.class;
+                    break;
+                case "MapAnnotation":
+                    annotationType = MapAnnotation.class;
                     break;
                 case "TagAnnotation":
                     annotationType = TagAnnotation.class;

--- a/src/main/java/org/openmicroscopy/client/downloader/XmlAssembler.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/XmlAssembler.java
@@ -30,6 +30,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -63,7 +64,6 @@ import ome.xml.model.enums.EnumerationException;
 import omero.log.Logger;
 import omero.log.SimpleLogger;
 
-import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.SetMultimap;

--- a/src/main/java/org/openmicroscopy/client/downloader/XmlAssembler.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/XmlAssembler.java
@@ -64,6 +64,7 @@ import omero.log.Logger;
 import omero.log.SimpleLogger;
 
 import com.google.common.base.Function;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.SetMultimap;
 
@@ -161,6 +162,22 @@ public class XmlAssembler implements Closeable {
     private static final String OME_XML_CREATOR = "OMERO.downloader";
 
     private static final OMEModel STATELESS_MODEL = new StatelessModel();
+
+    private static final Map<String, Class<? extends Annotation>> ANNOTATION_TYPES;
+
+    static {
+        final ImmutableMap.Builder<String, Class<? extends Annotation>> map = ImmutableMap.builder();
+        map.put("BooleanAnnotation", BooleanAnnotation.class);
+        map.put("CommentAnnotation", CommentAnnotation.class);
+        map.put("DoubleAnnotation", DoubleAnnotation.class);
+        map.put("LongAnnotation", LongAnnotation.class);
+        map.put("MapAnnotation", MapAnnotation.class);
+        map.put("TagAnnotation", TagAnnotation.class);
+        map.put("TermAnnotation", TermAnnotation.class);
+        map.put("TimestampAnnotation", TimestampAnnotation.class);
+        map.put("XMLAnnotation", XMLAnnotation.class);
+        ANNOTATION_TYPES = map.build();
+    }
 
     private static final OME OME_OBJECT;
 
@@ -326,36 +343,9 @@ public class XmlAssembler implements Closeable {
                     Download.abortOnFatalError(3);
                 }
             }
-            switch (element.getNodeName()) {
-                case "BooleanAnnotation":
-                    annotationType = BooleanAnnotation.class;
-                    break;
-                case "CommentAnnotation":
-                    annotationType = CommentAnnotation.class;
-                    break;
-                case "DoubleAnnotation":
-                    annotationType = DoubleAnnotation.class;
-                    break;
-                case "LongAnnotation":
-                    annotationType = LongAnnotation.class;
-                    break;
-                case "MapAnnotation":
-                    annotationType = MapAnnotation.class;
-                    break;
-                case "TagAnnotation":
-                    annotationType = TagAnnotation.class;
-                    break;
-                case "TermAnnotation":
-                    annotationType = TermAnnotation.class;
-                    break;
-                case "TimestampAnnotation":
-                    annotationType = TimestampAnnotation.class;
-                    break;
-                case "XMLAnnotation":
-                    annotationType = XMLAnnotation.class;
-                    break;
-                default:
-                    throw new IllegalArgumentException("annotation " + id + " has element " + element);
+            annotationType = ANNOTATION_TYPES.get(element.getNodeName());
+            if (annotationType == null) {
+                throw new IllegalArgumentException("annotation " + id + " has element " + element);
             }
             annotationTypes.put(id, annotationType);
         }
@@ -365,7 +355,6 @@ public class XmlAssembler implements Closeable {
             LOGGER.fatal(roe, "cannot instantiate " + annotationType);
             Download.abortOnFatalError(3);
             return null;
-
         }
     }
 

--- a/src/main/java/org/openmicroscopy/client/downloader/XmlGenerator.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/XmlGenerator.java
@@ -180,13 +180,6 @@ public class XmlGenerator {
     private final IQueryPrx iQuery;
     private final String format;
 
-    private final Function<IObject, String> lsidGetter = new Function<IObject, String>() {
-        @Override
-        public String apply(IObject object) {
-            return getLsid(object);
-        }
-    };
-
     /**
      * Query the parent-child relationships among model objects.
      * @param listener the listener to notify of parent-child relationships
@@ -397,7 +390,7 @@ public class XmlGenerator {
     public void writeAnnotations(List<Long> ids, MetadataStore destination) throws ServerError {
         for (final List<Long> annotationIdBatch : Lists.partition(ids, BATCH_SIZE)) {
             final List<Annotation> annotations = getAnnotations(annotationIdBatch);
-            omeXmlService.convertMetadata(new AnnotationMetadata(lsidGetter, annotations), destination);
+            omeXmlService.convertMetadata(new AnnotationMetadata(this::getLsid, annotations), destination);
         }
     }
 
@@ -410,7 +403,7 @@ public class XmlGenerator {
     public void writeImages(List<Long> ids, MetadataStore destination) throws ServerError {
         for (final List<Long> imageIdBatch : Lists.partition(ids, BATCH_SIZE)) {
             final List<Image> images = getImages(imageIdBatch);
-            omeXmlService.convertMetadata(new ImageMetadata(lsidGetter, images), destination);
+            omeXmlService.convertMetadata(new ImageMetadata(this::getLsid, images), destination);
         }
     }
 
@@ -433,7 +426,7 @@ public class XmlGenerator {
                     roiIterator.remove();
                 }
             }
-            omeXmlService.convertMetadata(new RoiMetadata(lsidGetter, rois), destination);
+            omeXmlService.convertMetadata(new RoiMetadata(this::getLsid, rois), destination);
         }
     }
 
@@ -478,8 +471,8 @@ public class XmlGenerator {
                 for (final Annotation annotation : getAnnotations(toWrite.keySet())) {
                     final OMEXMLMetadata metadata = omeXmlService.createOMEXMLMetadata();
                     metadata.createRoot();
-                    omeXmlService.convertMetadata(new AnnotationMetadata(lsidGetter, Collections.singletonList(annotation)),
-                            metadata);
+                    omeXmlService.convertMetadata(new AnnotationMetadata(XmlGenerator.this::getLsid,
+                            Collections.singletonList(annotation)), metadata);
                     final OME omeElement = (OME) metadata.getRoot();
                     final ome.xml.model.Annotation annotationElement;
                     if (annotation instanceof BooleanAnnotation) {
@@ -527,7 +520,8 @@ public class XmlGenerator {
                 for (final Image image : getImages(toWrite.keySet())) {
                     final OMEXMLMetadata metadata = omeXmlService.createOMEXMLMetadata();
                     metadata.createRoot();
-                    omeXmlService.convertMetadata(new ImageMetadata(lsidGetter, Collections.singletonList(image)), metadata);
+                    omeXmlService.convertMetadata(new ImageMetadata(XmlGenerator.this::getLsid,
+                            Collections.singletonList(image)), metadata);
                     final OME omeElement = (OME) metadata.getRoot();
                     final ome.xml.model.Image imageElement = omeElement.getImage(0);
                     final ome.xml.model.Pixels pixels = imageElement.getPixels();
@@ -564,7 +558,8 @@ public class XmlGenerator {
                     }
                     final OMEXMLMetadata xmlMeta = omeXmlService.createOMEXMLMetadata();
                     xmlMeta.createRoot();
-                    omeXmlService.convertMetadata(new RoiMetadata(lsidGetter, Collections.singletonList(roi)), xmlMeta);
+                    omeXmlService.convertMetadata(new RoiMetadata(XmlGenerator.this::getLsid,
+                            Collections.singletonList(roi)), xmlMeta);
                     final OME omeElement = (OME) xmlMeta.getRoot();
                     final ome.xml.model.ROI roiElement = omeElement.getROI(0);
                     writeElement(roiElement, toWrite.get(roi.getId().getValue()));

--- a/src/main/java/org/openmicroscopy/client/downloader/XmlGenerator.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/XmlGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2016-2019 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -70,6 +70,7 @@ import omero.model.DoubleAnnotation;
 import omero.model.IObject;
 import omero.model.Image;
 import omero.model.LongAnnotation;
+import omero.model.MapAnnotation;
 import omero.model.Mask;
 import omero.model.Roi;
 import omero.model.Shape;
@@ -489,6 +490,8 @@ public class XmlGenerator {
                         annotationElement = omeElement.getStructuredAnnotations().getDoubleAnnotation(0);
                     } else if (annotation instanceof LongAnnotation) {
                         annotationElement = omeElement.getStructuredAnnotations().getLongAnnotation(0);
+                    } else if (annotation instanceof MapAnnotation) {
+                        annotationElement = omeElement.getStructuredAnnotations().getMapAnnotation(0);
                     } else if (annotation instanceof TagAnnotation) {
                         annotationElement = omeElement.getStructuredAnnotations().getTagAnnotation(0);
                     } else if (annotation instanceof TermAnnotation) {

--- a/src/main/java/org/openmicroscopy/client/downloader/XmlGenerator.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/XmlGenerator.java
@@ -19,7 +19,6 @@
 
 package org.openmicroscopy.client.downloader;
 
-import com.google.common.base.Function;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -41,6 +40,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;

--- a/src/main/java/org/openmicroscopy/client/downloader/metadata/AnnotationMetadata.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/metadata/AnnotationMetadata.java
@@ -22,6 +22,7 @@ package org.openmicroscopy.client.downloader.metadata;
 import java.util.ArrayList;
 import java.util.List;
 
+import ome.xml.model.MapPair;
 import ome.xml.model.primitives.Timestamp;
 
 import omero.model.Annotation;
@@ -29,6 +30,8 @@ import omero.model.BooleanAnnotation;
 import omero.model.CommentAnnotation;
 import omero.model.DoubleAnnotation;
 import omero.model.LongAnnotation;
+import omero.model.MapAnnotation;
+import omero.model.NamedValue;
 import omero.model.TagAnnotation;
 import omero.model.TermAnnotation;
 import omero.model.TimestampAnnotation;
@@ -52,6 +55,7 @@ public class AnnotationMetadata extends MetadataBase {
     private final List<CommentAnnotation> commentAnnotationList = new ArrayList<>();
     private final List<DoubleAnnotation> doubleAnnotationList = new ArrayList<>();
     private final List<LongAnnotation> longAnnotationList = new ArrayList<>();
+    private final List<MapAnnotation> mapAnnotationList = new ArrayList<>();
     private final List<TagAnnotation> tagAnnotationList = new ArrayList<>();
     private final List<TermAnnotation> termAnnotationList = new ArrayList<>();
     private final List<TimestampAnnotation> timestampAnnotationList = new ArrayList<>();
@@ -68,6 +72,8 @@ public class AnnotationMetadata extends MetadataBase {
                 doubleAnnotationList.add((DoubleAnnotation) annotation);
             } else if (annotation instanceof LongAnnotation) {
                 longAnnotationList.add((LongAnnotation) annotation);
+            } else if (annotation instanceof MapAnnotation) {
+                mapAnnotationList.add((MapAnnotation) annotation);
             } else if (annotation instanceof TagAnnotation) {
                 tagAnnotationList.add((TagAnnotation) annotation);
             } else if (annotation instanceof TermAnnotation) {
@@ -103,6 +109,10 @@ public class AnnotationMetadata extends MetadataBase {
             else if (klass.equals(CommentAnnotation.class))
             {
                 return (T) commentAnnotationList.get(index);
+            }
+            else if (klass.equals(MapAnnotation.class))
+            {
+                return (T) mapAnnotationList.get(index);
             }
             else if (klass.equals(TimestampAnnotation.class))
             {
@@ -315,6 +325,48 @@ public class AnnotationMetadata extends MetadataBase {
         CommentAnnotation o = getAnnotation(
                 CommentAnnotation.class, commentAnnotationIndex);
         return o != null? fromRType(o.getTextValue()) : null;
+    }
+
+    @Override
+    public int getMapAnnotationCount()
+    {
+        return mapAnnotationList.size();
+    }
+
+    @Override
+    public String getMapAnnotationDescription(int mapAnnotationIndex)
+    {
+        return getAnnotationDescription(
+                MapAnnotation.class, mapAnnotationIndex);
+    }
+
+    @Override
+    public String getMapAnnotationID(int mapAnnotationIndex)
+    {
+        return getAnnotationID(MapAnnotation.class, mapAnnotationIndex);
+    }
+
+    @Override
+    public String getMapAnnotationNamespace(int mapAnnotationIndex)
+    {
+        return getAnnotationNamespace(
+                MapAnnotation.class, mapAnnotationIndex);
+    }
+
+    @Override
+    public List<MapPair> getMapAnnotationValue(int mapAnnotationIndex)
+    {
+        final MapAnnotation ma = getAnnotation(
+                MapAnnotation.class, mapAnnotationIndex);
+        final List<NamedValue> namedValues = ma.getMapValue();
+        if (namedValues == null) {
+            return null;
+        }
+        final List<MapPair> mapPairs = new ArrayList<>(namedValues.size());
+        for (final NamedValue namedValue : namedValues) {
+            mapPairs.add(new MapPair(namedValue.name, namedValue.value));
+        }
+        return mapPairs;
     }
 
     @Override

--- a/src/main/java/org/openmicroscopy/client/downloader/metadata/AnnotationMetadata.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/metadata/AnnotationMetadata.java
@@ -21,6 +21,7 @@ package org.openmicroscopy.client.downloader.metadata;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 import ome.xml.model.MapPair;
 import ome.xml.model.primitives.Timestamp;
@@ -37,8 +38,6 @@ import omero.model.TermAnnotation;
 import omero.model.TimestampAnnotation;
 import omero.model.XmlAnnotation;
 import omero.model.IObject;
-
-import com.google.common.base.Function;
 
 import org.joda.time.Instant;
 

--- a/src/main/java/org/openmicroscopy/client/downloader/metadata/ImageMetadata.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/metadata/ImageMetadata.java
@@ -20,6 +20,7 @@
 package org.openmicroscopy.client.downloader.metadata;
 
 import java.util.List;
+import java.util.function.Function;
 
 import static ome.formats.model.UnitsFactory.convertLength;
 
@@ -43,8 +44,6 @@ import omero.model.Image;
 import omero.model.Pixels;
 import omero.model.PlaneInfo;
 import omero.model.Roi;
-
-import com.google.common.base.Function;
 
 import org.joda.time.Instant;
 

--- a/src/main/java/org/openmicroscopy/client/downloader/metadata/MetadataBase.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/metadata/MetadataBase.java
@@ -45,6 +45,8 @@ import omero.model.IObject;
  */
 abstract class MetadataBase extends DummyMetadata {
 
+    private static final MetadataRoot ROOT = new MetadataRoot() {};
+
     private final Function<IObject, String> lsids;
 
     protected MetadataBase(Function<IObject, String> lsids) {
@@ -94,7 +96,6 @@ abstract class MetadataBase extends DummyMetadata {
 
     @Override
     public MetadataRoot getRoot() {
-        return new MetadataRoot() {
-        };
+        return ROOT;
     }
 }

--- a/src/main/java/org/openmicroscopy/client/downloader/metadata/MetadataBase.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/metadata/MetadataBase.java
@@ -19,7 +19,7 @@
 
 package org.openmicroscopy.client.downloader.metadata;
 
-import com.google.common.base.Function;
+import java.util.function.Function;
 
 import loci.formats.meta.DummyMetadata;
 

--- a/src/main/java/org/openmicroscopy/client/downloader/metadata/RoiMetadata.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/metadata/RoiMetadata.java
@@ -20,6 +20,7 @@
 package org.openmicroscopy.client.downloader.metadata;
 
 import java.util.List;
+import java.util.function.Function;
 
 import ome.formats.model.UnitsFactory;
 import ome.units.quantity.Length;
@@ -44,8 +45,6 @@ import omero.model.Polyline;
 import omero.model.Rectangle;
 import omero.model.Roi;
 import omero.model.Shape;
-
-import com.google.common.base.Function;
 
 /**
  * An instance of {@link loci.formats.meta.MetadataRetrieve} that provides metadata about OMERO ROIs.


### PR DESCRIPTION
This PR fixes #17 by reverting #10 and reworks annotation processing while adopting https://github.com/ome/omero-blitz/pull/37. Enough code has been touched that it would be worth working through both the "File exports" and "Fetching metadata" sections of the [testing scenario](https://docs.openmicroscopy.org/internal/testing_scenarios/OMEROdownloader.html). Include map annotations among your test data.