### PR TITLE
Update to target imminent v0.2.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.2.0 (July 2019)
+
+Work against OMERO 5.5 servers.
+(PR [\#22](https://github.com/ome/omero-downloader/pull/22))
+
+
 # 0.1.5 (May 2019)
 
 - Automatically adapt to inability to create symbolic links.

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>omero</groupId>
   <artifactId>downloader</artifactId>
-  <version>0.1.6-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
 
   <name>OMERO.downloader</name>
   <description>OMERO client for downloading data in bulk from the server</description>


### PR DESCRIPTION
Targets the v0.2.0 breaking release that works against OMERO 5.5 servers.