### PR TITLE
Unidata NetCDF artifacts are now mirrored on OME artifactory.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,11 +95,6 @@
         <name>OME Maven Artifactory</name>
         <url>https://artifacts.openmicroscopy.org/artifactory/maven</url>
       </repository>
-      <repository>
-        <id>unidata</id>
-        <name>Unidata Repository</name>
-        <url>https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases</url>
-      </repository>
   </repositories>
 
   <build>


### PR DESCRIPTION
Removes the Unidata NetCDF repository from the POM now it is no longer needed.