### PR TITLE
Have OMERO.downloader work with both OMERO 5.5 and 5.6.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Binaries can be downloaded from the
 [releases](https://github.com/ome/omero-downloader/releases) page.
 
 NB: Use OMERO.downloader `0.1.5` to work with OMERO.server `5.4.x`.
-Use OMERO.downloader `0.2.x` to work with OMERO.server `5.5.x`.
+Use OMERO.downloader `0.2.x` to work with OMERO.server `5.5.x` and later `5.x`.
 
 For development, from the source repository `mvn` builds and packages the downloader.
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.openmicroscopy</groupId>
+        <artifactId>omero-gateway</artifactId>
+        <version>5.6.2</version>
+      </dependency>
+      <dependency>
         <groupId>commons-cli</groupId>
         <artifactId>commons-cli</artifactId>
         <version>1.4</version>
@@ -61,7 +66,6 @@
     <dependency>
       <groupId>org.openmicroscopy</groupId>
       <artifactId>omero-gateway</artifactId>
-      <version>5.5.3</version>
       <exclusions>
         <exclusion>
           <groupId>org.testng</groupId>


### PR DESCRIPTION
Fixes https://github.com/ome/omero-downloader/issues/29 to use latest Java Gateway that understands the new semantic versioning.