### PR TITLE
Write TIFF tiles sequentially.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ export regardless of images.
 
 Available as Open Source: see [the license](LICENSE.txt) for details.
 
-Copyright (C) 2016-2019 University of Dundee & Open Microscopy Environment.
+Copyright (C) 2016-2020 University of Dundee & Open Microscopy Environment.
 All rights reserved.
 
 

--- a/src/main/java/org/openmicroscopy/client/downloader/Download.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/Download.java
@@ -693,6 +693,7 @@ public class Download {
                         }
                         writer.setCompression(TiffWriter.COMPRESSION_ZLIB);
                         writer.setMetadataRetrieve(metadata);
+                        writer.setWriteSequentially(true);
                         writer.setId(tiffFile.getPath());
                         localPixels.writeTiles(writer);
                     }

--- a/src/main/java/org/openmicroscopy/client/downloader/LocalPixels.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/LocalPixels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2016-2020 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -158,17 +158,20 @@ public class LocalPixels {
         int tileNumber = 0;
         int planeIndex = -1;
         TileIterator.Tile previousTile = null;
+        IFD ifd = null;
         for (final TileIterator.Tile tile : tiles) {
             if (!tile.isSamePlane(previousTile)) {
                 previousTile = tile;
                 planeIndex++;
+                if (writer instanceof TiffWriter) {
+                    /* TiffWriter requires an IFD for each plane of tiled writing */
+                    ifd = new IFD();
+                    ifd.put(IFD.TILE_WIDTH, tileSize.width);
+                    ifd.put(IFD.TILE_LENGTH, tileSize.height);
+                }
             }
             final byte[] pixels = tileIO.readBytes(tileSizes[tileNumber]);
             if (writer instanceof TiffWriter) {
-              /* TiffWriter requires IFD for tiled writing */
-              final IFD ifd = new IFD();
-              ifd.put(IFD.TILE_WIDTH, tileSize.width);
-              ifd.put(IFD.TILE_LENGTH, tileSize.height);
               ((TiffWriter) writer).saveBytes(planeIndex, pixels, ifd, tile.x, tile.y, tile.w, tile.h);
             } else {
               writer.saveBytes(planeIndex, pixels, tile.x, tile.y, tile.w, tile.h);

--- a/src/main/java/org/openmicroscopy/client/downloader/LocalPixels.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/LocalPixels.java
@@ -172,9 +172,9 @@ public class LocalPixels {
             }
             final byte[] pixels = tileIO.readBytes(tileSizes[tileNumber]);
             if (writer instanceof TiffWriter) {
-              ((TiffWriter) writer).saveBytes(planeIndex, pixels, ifd, tile.x, tile.y, tile.w, tile.h);
+                ((TiffWriter) writer).saveBytes(planeIndex, pixels, ifd, tile.x, tile.y, tile.w, tile.h);
             } else {
-              writer.saveBytes(planeIndex, pixels, tile.x, tile.y, tile.w, tile.h);
+                writer.saveBytes(planeIndex, pixels, tile.x, tile.y, tile.w, tile.h);
             }
             if (tileNumber % TILES_PER_DOT == 0) {
                 System.out.print('.');


### PR DESCRIPTION
Final fix for https://github.com/ome/omero-downloader/issues/17 superseding #10. Test using the [file exports scenario](https://docs.openmicroscopy.org/internal/testing_scenarios/OMEROdownloader.html#file-exports) (note the initial "Preparation" section) or otherwise test (OME-)TIFF export with images including big ones and 5D ones, viewing the images to make sure that they look correctly exported.