### PR TITLE
Prepare for 0.2.1 release to permit OMERO 5.6.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.2.1 (January 2020)
+
+- Remove the Unidata NetCDF repository. (PR [\#28](https://github.com/ome/omero-downloader/pull/28))
+- Work against OMERO 5.5 and 5.6 servers. (PR [\#31](https://github.com/ome/omero-downloader/pull/31))
+- Set `writeSequentially` to improve performance. (PR [\#32](https://github.com/ome/omero-downloader/pull/32))
+
 # 0.2.0 (July 2019)
 
 Work against OMERO 5.5 servers.

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>omero</groupId>
   <artifactId>downloader</artifactId>
-  <version>0.2.1-SNAPSHOT</version>
+  <version>0.2.1</version>
 
   <name>OMERO.downloader</name>
   <description>OMERO client for downloading data in bulk from the server</description>


### PR DESCRIPTION
Also updates [changelog](https://github.com/mtbc/omero-downloader/blob/OMERO-5.6/CHANGELOG.md).