### PR TITLE
Back to SNAPSHOT version after release.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>omero</groupId>
   <artifactId>downloader</artifactId>
-  <version>0.2.1</version>
+  <version>0.2.2-SNAPSHOT</version>
 
   <name>OMERO.downloader</name>
   <description>OMERO client for downloading data in bulk from the server</description>


### PR DESCRIPTION
https://github.com/ome/omero-downloader/releases/tag/v0.2.1 is now up.