### PR TITLE
Print duration of long-running operations.

### DIFF
--- a/src/main/java/org/openmicroscopy/client/downloader/Download.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/Download.java
@@ -102,6 +102,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import org.openmicroscopy.client.downloader.options.OptionParser;
+import org.openmicroscopy.client.downloader.util.TimeUtil;
 
 /**
  * OMERO client for downloading data in bulk from the server.
@@ -792,13 +793,14 @@ public class Download {
                         System.out.println("already assembled metadata for image " + imageId);
                         continue;
                     }
+                    final long startTime = System.nanoTime();
                     final File temporaryFile = new File(exportFile.getParentFile(), "temp-" + UUID.randomUUID());
                     try (final OutputStream out = new FileOutputStream(temporaryFile);
                          final XmlAssembler writer = new XmlAssembler(omeXmlService, containment, metadataFiles, out)) {
                         writer.writeImage(imageId);
                     }
                     temporaryFile.renameTo(exportFile);
-                    System.out.println(" done");
+                    TimeUtil.printDone(startTime);
                 }
             } else if (objects.containsKey(ModelType.ROI)) {
                 final Set<Long> roiIds = objects.get(ModelType.ROI);
@@ -815,13 +817,14 @@ public class Download {
                         System.out.println("already assembled metadata for ROI " + roiId);
                         continue;
                     }
+                    final long startTime = System.nanoTime();
                     final File temporaryFile = new File(exportFile.getParentFile(), "temp-" + UUID.randomUUID());
                     try (final OutputStream out = new FileOutputStream(temporaryFile);
                          final XmlAssembler writer = new XmlAssembler(omeXmlService, containment, metadataFiles, out)) {
                         writer.writeRoi(roiId);
                     }
                     temporaryFile.renameTo(exportFile);
-                    System.out.println(" done");
+                    TimeUtil.printDone(startTime);
                 }
             } else if (objects.containsKey(ModelType.ANNOTATION)) {
                 final Set<Long> annotationIds = objects.get(ModelType.ANNOTATION);
@@ -838,6 +841,7 @@ public class Download {
                         System.out.println("already assembled metadata for annotation " + annotationId);
                         continue;
                     }
+                    final long startTime = System.nanoTime();
                     final File temporaryFile = new File(exportFile.getParentFile(), "temp-" + UUID.randomUUID());
                     try (final OutputStream out = new FileOutputStream(temporaryFile);
                         final XmlAssembler writer = new XmlAssembler(omeXmlService, containment, metadataFiles, out)) {
@@ -847,7 +851,7 @@ public class Download {
                       throw ioe;
                     }
                     temporaryFile.renameTo(exportFile);
-                    System.out.println(" done");
+                    TimeUtil.printDone(startTime);
                 }
             }
         } catch (IOException ioe) {

--- a/src/main/java/org/openmicroscopy/client/downloader/FileManager.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/FileManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2016-2020 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -30,6 +30,8 @@ import omero.log.Logger;
 import omero.log.SimpleLogger;
 
 import com.google.common.math.IntMath;
+
+import org.openmicroscopy.client.downloader.util.TimeUtil;
 
 /**
  * Manage the remote and local locations of files.
@@ -63,6 +65,7 @@ public class FileManager {
                 }
                 System.out.print(" download of file " + fileId + "...");
                 System.out.flush();
+                final long startTime = System.nanoTime();
                 /* check for download restriction before creating local file */
                 fileStore.read(0, 0);
                 final OutputStream out = new FileOutputStream(destination, true);
@@ -79,7 +82,7 @@ public class FileManager {
                     System.out.print('.');
                     System.out.flush();
                 } while (bytesRemaining > 0);
-                System.out.println(" done");
+                TimeUtil.printDone(startTime);
                 out.close();
             }
         } catch (ServerError se) {

--- a/src/main/java/org/openmicroscopy/client/downloader/FileMapper.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/FileMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2016-2020 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -45,6 +45,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
+
+import org.openmicroscopy.client.downloader.util.TimeUtil;
 
 /**
  * Track the relationships among filesets, images, pixels and original files.
@@ -165,6 +167,7 @@ public class FileMapper {
         /* map the filesets of the targeted images */
         System.out.print("mapping filesets of images...");
         System.out.flush();
+        final long startTime = System.nanoTime();
         try {
             for (final List<Long> imageIdBatch : Lists.partition(ImmutableList.copyOf(imageIds), BATCH_SIZE)) {
                 final Set<Long> filesetsThisBatch = new HashSet<>();
@@ -229,7 +232,7 @@ public class FileMapper {
             }
             shortenPaths(fsFiles);
         }
-        System.out.println(" done");
+        TimeUtil.printDone(startTime);
     }
 
     /**

--- a/src/main/java/org/openmicroscopy/client/downloader/LocalPixels.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/LocalPixels.java
@@ -38,6 +38,7 @@ import omero.log.SimpleLogger;
 
 import org.openmicroscopy.client.downloader.util.FileIO;
 import org.openmicroscopy.client.downloader.util.TileIterator;
+import org.openmicroscopy.client.downloader.util.TimeUtil;
 
 /**
  * Download a remote image's tiles into a local file and assemble them into a TIFF file.
@@ -115,6 +116,7 @@ public class LocalPixels {
         }
         System.out.print(" download of pixels " + rps.getPixelsId() + "...");
         System.out.flush();
+        final long startTime = System.nanoTime();
         int tileNumber = 0;
         for (final TileIterator.Tile tile : tiles) {
             final long from = tileIO.tell();
@@ -137,7 +139,7 @@ public class LocalPixels {
             tileNumber++;
         }
         tileIO.close();
-        System.out.println(" done");
+        TimeUtil.printDone(startTime);
     }
 
     /**
@@ -150,6 +152,7 @@ public class LocalPixels {
     public void writeTiles(FormatWriter writer) throws FormatException, IOException, ServerError {
         System.out.print("assembling pixels " + rps.getPixelsId() + "..");
         System.out.flush();
+        final long startTime = System.nanoTime();
         final FileIO tileIO = new FileIO(tileFile, false);
         final int[] tileSizes = new int[tileIO.readInt()];
         for (int tileNumber = 0; tileNumber < tileSizes.length; tileNumber++) {
@@ -184,6 +187,6 @@ public class LocalPixels {
         }
         writer.close();
         tileIO.close();
-        System.out.println(" done");
+        TimeUtil.printDone(startTime);
     }
 }

--- a/src/main/java/org/openmicroscopy/client/downloader/RequestManager.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/RequestManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2016-2020 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -32,6 +32,8 @@ import omero.gateway.Gateway;
 import omero.gateway.SecurityContext;
 
 import org.apache.commons.lang3.StringUtils;
+
+import org.openmicroscopy.client.downloader.util.TimeUtil;
 
 /**
  * Manage submission of requests to the OMERO server.
@@ -66,6 +68,7 @@ public class RequestManager {
     public <X extends Response> X submit(String action, Request request, Class<X> responseClass) {
         System.out.print(action + "...");
         System.out.flush();
+        final long startTime = System.nanoTime();
         int thisTimeout = timeoutSeconds;
         CmdCallbackI callback = null;
         try {
@@ -97,7 +100,7 @@ public class RequestManager {
         }
         try {
             final X desiredResponse = responseClass.cast(response);
-            System.out.println(" done");
+            TimeUtil.printDone(startTime);
             return desiredResponse;
         } catch (ClassCastException cce) {
             if (response instanceof GraphException) {

--- a/src/main/java/org/openmicroscopy/client/downloader/XmlGenerator.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/XmlGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2019 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2016-2020 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -84,6 +84,7 @@ import omero.sys.ParametersI;
 import org.openmicroscopy.client.downloader.metadata.AnnotationMetadata;
 import org.openmicroscopy.client.downloader.metadata.ImageMetadata;
 import org.openmicroscopy.client.downloader.metadata.RoiMetadata;
+import org.openmicroscopy.client.downloader.util.TimeUtil;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -586,6 +587,7 @@ public class XmlGenerator {
             System.out.print(", already have " + alreadyHave);
         }
         System.out.print("..");
+        final long startTime = System.nanoTime();
         try {
             for (final List<Long> idBatch : Lists.partition(ImmutableList.copyOf(files.keySet()), BATCH_SIZE)) {
                 System.out.print('.');
@@ -596,7 +598,7 @@ public class XmlGenerator {
                 }
                 objectWriter.writeObjects(toWrite.build());
             }
-            System.out.println(" done");
+            TimeUtil.printDone(startTime);
         } catch (IOException | ServerError | ServiceException | TransformerException e) {
             System.out.println(" failed");
             LOGGER.error(e, "failed to obtain " + objectWriter.getObjectsName() +" and write as XML");

--- a/src/main/java/org/openmicroscopy/client/downloader/util/TimeUtil.java
+++ b/src/main/java/org/openmicroscopy/client/downloader/util/TimeUtil.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2020 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package org.openmicroscopy.client.downloader.util;
+
+import java.time.Duration;
+
+/**
+ * Utility methods related to chronology.
+ * @author m.t.b.carroll@dundee.ac.uk
+ */
+public class TimeUtil {
+    /**
+     * End a progress line with a <q>done</q> message that may include a duration.
+     * @param startTime the start time of the just-completed operation, as previously from {@link System#nanoTime()}
+     */
+    public static void printDone(long startTime) {
+        final long endTime = System.nanoTime();
+        final Duration duration = Duration.ofNanos(endTime - startTime);
+        final long seconds = duration.getSeconds();
+        System.out.print(" done");
+        if (seconds > 0) {
+            System.out.print(String.format(" (%,ds)", seconds));
+        }
+        System.out.println();
+    }
+}


### PR DESCRIPTION
Now, when running downloads, any line that ends "done" that takes more than a moment should be given a duration suffix.